### PR TITLE
Add support for M1 Macs

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -21,6 +21,15 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+        
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
 
       - name: Build and push image
         uses: docker/build-push-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@ RUN wget "https://raw.githubusercontent.com/zcash/zcash/master/zcutil/fetch-para
   && export OSTYPE=linux \
   && sed '/SAPLING_SPROUT_GROTH16_NAME/d; /progress/d; /retry-connrefused/d' fetch-params.sh | sh \
   && rm fetch-params.sh
+ARG TARGETPLATFORM
 ARG TAG
-RUN wget "https://github.com/serokell/tezos-packaging/releases/download/$TAG/tezos-node" \
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then EXEC_NAME="tezos-node-arm64"; else EXEC_NAME="tezos-node"; fi \
+  && wget "https://github.com/serokell/tezos-packaging/releases/download/$TAG/$EXEC_NAME" -O "tezos-node" \
   && chmod +x tezos-node
 RUN ./tezos-node identity generate "0.0" --data-dir /tezos/sandbox
 COPY ./*.json /tezos/sandbox/

--- a/hooks/build
+++ b/hooks/build
@@ -1,2 +1,2 @@
 #!/bin/bash -xe
-docker build --build-arg TAG=$DOCKER_TAG -t $IMAGE_NAME .
+docker buildx build --platform linux/arm64,linux/amd64 --build-arg TAG=$DOCKER_TAG -t $IMAGE_NAME .


### PR DESCRIPTION
`pytest` fails with `qemu segmentation failed` for this docker image when run on M1 Mac.

This PR adds support for fetching `tezos-node-arm64` binary in case docker target build platform is `linux/arm64`.

It requires changes to `docker build` command invocation. I have tested it to build and pass sandboxed tests on my machine.
I have also changed Github workflows and checked that images are build successfully in my forked repo.
Although I haven't been able to check how images are uploaded to the Docker hub.
